### PR TITLE
checkpoint-API-And-DB :- Intialized the API Key, Stock Dao, CompanyListing and its entity keep clear spearation of concerns.

### DIFF
--- a/app/src/main/java/com/plcoding/stockmarketapp/data/local/CompanyListingEntity.kt
+++ b/app/src/main/java/com/plcoding/stockmarketapp/data/local/CompanyListingEntity.kt
@@ -1,0 +1,12 @@
+package com.plcoding.stockmarketapp.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity
+data class CompanyListingEntity(
+    val name: String,
+    val symbol: String,
+    val exchange: String,
+    @PrimaryKey val id: Int? = null // When annotated with @Primary key room will automatically generate primary key for us
+)

--- a/app/src/main/java/com/plcoding/stockmarketapp/data/local/StockDao.kt
+++ b/app/src/main/java/com/plcoding/stockmarketapp/data/local/StockDao.kt
@@ -1,0 +1,29 @@
+package com.plcoding.stockmarketapp.data.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+//Stock Data access object
+@Dao
+interface StockDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertCompanyListings(
+        companyListingEntities: List<CompanyListingEntity>
+    )
+
+    @Query("DELETE FROM companylistingentity")
+    suspend fun clearCompanyListings()
+
+    @Query(
+        """
+            SELECT * 
+            FROM companylistingentity
+            WHERE LOWER(name) like '%' || LOWER(:query) || '%' OR 
+                UPPER(:query) == symbol
+        """
+    )
+    suspend fun searchCompanyListing(query: String): List<CompanyListingEntity>
+}

--- a/app/src/main/java/com/plcoding/stockmarketapp/data/local/StockDatabase.kt
+++ b/app/src/main/java/com/plcoding/stockmarketapp/data/local/StockDatabase.kt
@@ -1,0 +1,12 @@
+package com.plcoding.stockmarketapp.data.local
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+@Database(
+    entities = [CompanyListingEntity::class],
+    version = 1
+)
+abstract class StockDatabase : RoomDatabase() {
+    abstract val dao: StockDao
+}

--- a/app/src/main/java/com/plcoding/stockmarketapp/data/mapper/CompanyMapper.kt
+++ b/app/src/main/java/com/plcoding/stockmarketapp/data/mapper/CompanyMapper.kt
@@ -1,0 +1,21 @@
+package com.plcoding.stockmarketapp.data.mapper
+
+import com.plcoding.stockmarketapp.data.local.CompanyListingEntity
+import com.plcoding.stockmarketapp.domain.model.CompanyListing
+
+// we are defining our mappers in our data layer to access the companylisting info from the domain layer since domain layer is the innermost layer in clean architecture
+fun CompanyListingEntity.toCompanyListing(): CompanyListing {
+    return CompanyListing(
+        name = name,
+        symbol = symbol,
+        exchange = exchange
+    )
+}
+
+fun CompanyListing.toCompanyListingEntity(): CompanyListingEntity {
+    return CompanyListingEntity(
+        name = name,
+        symbol = symbol,
+        exchange = exchange
+    )
+}

--- a/app/src/main/java/com/plcoding/stockmarketapp/data/remote/StockApi.kt
+++ b/app/src/main/java/com/plcoding/stockmarketapp/data/remote/StockApi.kt
@@ -1,0 +1,19 @@
+package com.plcoding.stockmarketapp.data.remote
+
+import okhttp3.ResponseBody
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface StockApi {
+
+
+    @GET("query?function=LISTING_STATUS") //query the API with LISTING_STATUS to get ResponseBody
+    suspend fun getListings(
+        @Query("apiKey") apiKey: String
+    ): ResponseBody
+
+    companion object {
+        const val API_KEY = "TBSKJWBUPC5EHBQV"
+        const val BASE_URL = "https://alphavantage.co"
+    }
+}

--- a/app/src/main/java/com/plcoding/stockmarketapp/domain/model/CompanyListing.kt
+++ b/app/src/main/java/com/plcoding/stockmarketapp/domain/model/CompanyListing.kt
@@ -1,0 +1,9 @@
+package com.plcoding.stockmarketapp.domain.model
+
+// we will only use these type of domain data models to show in UI because by doing this it
+// has no relation with the data level models because in data level we are using third party libraries.
+data class CompanyListing(
+    val name: String,
+    val symbol: String,
+    val exchange: String,
+)


### PR DESCRIPTION
In this pull request I have initialized the package structure for the app along with initial files such as API class, Stock Dao, Stock Database.

The main thing I implemented is the mapper class called "CompanyMapper" where I've implemented two extension functions, toCompanyListing() and toCompanyListingEntity(), which serve as mappers between the data layer and the domain layer. This practice aligns with the principles of Clean Architecture, a design philosophy that emphasizes separation of concerns.

In Clean Architecture, the domain layer encapsulates the core business logic, remaining independent of external concerns like data storage or APIs. On the other hand, the data layer handles interactions with databases, APIs, and other external services. To maintain this separation, it's crucial to avoid direct dependencies from the domain layer to the data layer.

By employing these mapper functions in the data layer, we can convert entities between the domain layer's CompanyListing and the data layer's CompanyListingEntity. This abstraction shields the domain layer from implementation details, allowing changes in the data layer without affecting the core business logic.

In essence, the use of mappers facilitates a clean and modular architecture. It promotes code maintainability, flexibility, and scalability by isolating the concerns of different layers and enabling changes to be made in one layer without disrupting the others. This aligns with the overarching principles of Clean Architecture, contributing to a more robust and adaptable software design.